### PR TITLE
Issue #6. Fixed chat crashing client

### DIFF
--- a/src/ChannelServer/Network/ChannelPacketSender.cs
+++ b/src/ChannelServer/Network/ChannelPacketSender.cs
@@ -614,6 +614,7 @@ namespace Melia.Channel.Network
 			}
 
 			packet.PutFloat(0); // Display time in seconds, min cap 5s
+			packet.PutEmptyBin(16); // message starts at 180 bytes.
 			packet.PutString(message);
 
 			character.Map.Broadcast(packet, character);


### PR DESCRIPTION
This fix inserts padding bytes so that `ZC_CHAT` contents start at 180 bytes offset from the beginning of the packet. 

The reason for the client crash was because of a `memcpy` instruction that tries to copy a character array out of bounds.

Fixes: https://github.com/celophi/melia/issues/6